### PR TITLE
Fix deps failure

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: NVD clojure
-      uses: jomco/nvd-clojure-action@v2
+      uses: jomco/nvd-clojure-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Cache lein project dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: "~/.m2/repository"
         key: "${{ runner.os }}-clojure-${{ hashFiles('**/project.clj') }}"
@@ -32,10 +32,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Cache lein project dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: "~/.m2/repository"
         key: "${{ runner.os }}-clojure-${{ hashFiles('**/project.clj') }}"
@@ -44,14 +44,14 @@ jobs:
       run: lein check-deps
 
     - name: NVD clojure
-      uses: jomco/nvd-clojure-action@v2
+      uses: jomco/nvd-clojure-action@v3
 
   docker-build:
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Run docker build
       run: docker build .

--- a/.nvd-suppressions.xml
+++ b/.nvd-suppressions.xml
@@ -1,3 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress>
+    <notes>Using clojure higher than 1.9.0 and not earlier as implied by some dependencies.</notes>
+    <cve>CVE-2017-20189</cve>
+  </suppress>
 </suppressions>

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
                  [nl.jomco/envopts "0.0.4"]
 
                  ;; web
-                 [compojure "1.7.0"]
+                 [compojure "1.7.1"]
                  [hiccup "1.0.5"]
                  [ring-oauth2 "0.2.2"] ;; TODO waarom kan die?
                  [ring/ring-core "1.11.0"]


### PR DESCRIPTION
Our dependencies seem to import older versions of clojure making NVD trip over clojure pre 1.9.0 which has a vulnerability but we're not using an old version of clojure.