### PR TITLE
Improve GH action triggers for dependency checks

### DIFF
--- a/.github/workflows/ancient.yml
+++ b/.github/workflows/ancient.yml
@@ -1,0 +1,25 @@
+name: Check deps for freshness
+
+on:
+  schedule:
+    - cron: '0 1 1 * 1' # every first of the month
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  deps:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Cache lein project dependencies
+      uses: actions/cache@v4
+      with:
+        path: "~/.m2/repository"
+        key: "${{ runner.os }}-clojure-${{ hashFiles('**/project.clj') }}"
+
+    - name: Check dependency freshness
+      run: lein check-deps

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -1,8 +1,11 @@
 name: Check deps for vulnerabilities
 
 on:
+  push:
+    branches: ["*"]
+    tags: ["*"]
   schedule:
-    - cron: '0 1 * * 1'
+    - cron: '0 1 * * 1,2,3,4,5' # every workday
 
 jobs:
   deps:
@@ -15,6 +18,12 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Cache lein project dependencies
+      uses: actions/cache@v4
+      with:
+        path: "~/.m2/repository"
+        key: "${{ runner.os }}-clojure-${{ hashFiles('**/project.clj') }}"
 
     - name: NVD clojure
       uses: jomco/nvd-clojure-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Run tests and docker build
 on: push
 
 jobs:
@@ -23,28 +23,6 @@ jobs:
 
     - name: Run compile
       run: lein uberjar
-
-  deps:
-    runs-on: ubuntu-latest
-
-    env:
-      NVD_API_TOKEN: ${{ secrets.NVD_API_TOKEN }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Cache lein project dependencies
-      uses: actions/cache@v4
-      with:
-        path: "~/.m2/repository"
-        key: "${{ runner.os }}-clojure-${{ hashFiles('**/project.clj') }}"
-
-    - name: Check dependency freshness
-      run: lein check-deps
-
-    - name: NVD clojure
-      uses: jomco/nvd-clojure-action@v3
 
   docker-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reorganised workflow into 3 separate flows:

- nvd

  On every push and every workday.

- test

  On every push.

- ancient

  Run it when opening / reopening a PR, and every first of the month.
